### PR TITLE
fixes embedded script tags from displaying as "</scriptscript>"

### DIFF
--- a/grammars/coldfusion.cson
+++ b/grammars/coldfusion.cson
@@ -126,26 +126,42 @@
     ]
   }
   {
-    'begin': '(?:^\\s+)?<((?i:script))\\b(?![^>]*/>)'
-    'captures':
+    'begin': '(?:^\\s+)?(<)((?i:script))\\b(?![^>]*/>)'
+    'beginCaptures':
       '1':
+        'name': 'punctuation.definition.tag.html'
+      '2':
         'name': 'entity.name.tag.script.html'
-    'end': '(?<=</(script|SCRIPT))>(?:\\s*\\n)?'
+    'end': '(?<=</(script|SCRIPT))(>)(?:\\s*\\n)?'
+    'endCaptures':
+      '2':
+        'name': 'punctuation.definition.tag.html'
     'name': 'source.js.embedded.html'
     'patterns': [
       {
         'include': '#tag-stuff'
       }
       {
-        'begin': '(?<!</(?:script|SCRIPT))>'
-        'end': '</((?i:script))'
+        'begin': '(?<!</(?:script|SCRIPT))(>)'
+        'captures':
+          '1':
+            'name': 'punctuation.definition.tag.html'
+          '2':
+            'name': 'entity.name.tag.script.html'
+        'end': '(</)((?i:script))'
         'patterns': [
           {
-            'match': '//.*?((?=</script)|$\\n?)'
+            'captures':
+              '1':
+                'name': 'punctuation.definition.comment.js'
+            'match': '(//).*?((?=</script)|$\\n?)'
             'name': 'comment.line.double-slash.js'
           }
           {
             'begin': '/\\*'
+            'captures':
+              '0':
+                'name': 'punctuation.definition.comment.js'
             'end': '\\*/|(?=</script)'
             'name': 'comment.block.js'
           }


### PR DESCRIPTION
Embedded javascript <script></script> tags in a CF file display the end tag as "</scriptscript>".  Similar issue to the previous issue with cfscript tags.
