### PR TITLE
smart grammar switching for .cfc files

### DIFF
--- a/grammars/cfscript.cson
+++ b/grammars/cfscript.cson
@@ -7,6 +7,79 @@
 ]
 'patterns': [
   {
-    'include': 'source.js'
+    'include': '#cfscript-files'
   }
 ]
+'repository':
+  'cfscript-files':
+    'name': 'source.cfscript'
+    'patterns': [
+      {
+        'begin':'^\\s*(import)\\s'
+        'end':';'
+        'beginCaptures':
+          '1':
+            'name':'entity.tag.name.script'
+        'patterns': [{'include': '#script-component-path'},{'include': '#script-component-name'}]
+      }
+      {
+        'match': '^\\s*(?i:\\b(component|interface|import|savecontent|property|param|transaction|query|document|setting|loop|(cf[a-zA-Z]+)(?=\\s*\\())\\b)'
+        'name': 'entity.tag.name.script'
+      }
+      {
+        'match': '^\\s*(?i:((write)?dump|writeoutput|throw))\\('
+        'captures':
+            '1':
+                'name': 'keyword.control.js entity.other.cfml.bif'
+      }
+      {
+        'match': '.?var\\s'
+        'name': 'storage.modifier.var'
+      }
+      {
+        'match': '\\b(variables|request|form|url)\\.'
+        'captures':
+          '1':
+            'name': 'entity.other.scope-name'
+      }
+      {
+        'begin':'\\s(extends)\\s*="?'
+        'end':'\\s'
+        'beginCaptures':
+          '1':
+            'name':'storage.modifier'
+        'patterns': [{'include': '#script-component-path'},{'include': '#script-component-name'}]
+      }
+      {
+        'begin':'\\s(new)\\s'
+        'end':'\\('
+        'beginCaptures':
+          '1':
+            'name':'keyword.operator.new'
+        'patterns': [{'include': '#script-component-path'},{'include': '#script-component-ctor'}]
+      }
+      {
+        'include': 'source.js'
+      }
+    ]
+  'script-component-path':
+    'patterns': [
+      {
+        'match': '(\\w+\\.)+'
+        'name': 'entity.name.package'
+      }
+    ]
+  'script-component-ctor':
+    'patterns': [
+      {
+        'match': '\\w+'
+        'name': 'entity.name.type.component.constructor'
+      }
+    ]
+  'script-component-name':
+    'patterns': [
+      {
+        'match': '\\w+'
+        'name': 'entity.name.type.component'
+      }
+    ]

--- a/lib/languageCFML.js
+++ b/lib/languageCFML.js
@@ -1,0 +1,49 @@
+module.exports = {
+	activate: function() {
+		module.cfmlGrammar = atom.grammars.grammarForScopeName("text.cf.cfml");
+		module.cfscriptGrammar = atom.grammars.grammarForScopeName("text.cf.cfscript");
+
+		atom.workspace.emitter.on("did-open", function(tab){
+			if (tab.item.getURI().endsWith("cfc")) {
+				bindChangeChecker(tab.item);
+				return checkCfscriptEditorGrammar(tab.item);
+			}
+		});
+
+		for (var editor of atom.workspace.getTextEditors()) {
+			if (editor.getURI().endsWith("cfc")) {
+				bindChangeChecker(editor);
+				checkCfscriptEditorGrammar(editor);
+			}
+		}
+	}
+};
+
+/**
+ * Check the current editor, if it is a CFC editor, and auto-switch to the cfscript grammar if necessary
+ */
+function checkCfscriptEditorGrammar(editor) {
+	if (!editor._checking_is_cfscript) {
+		editor._checking_is_cfscript=true;
+
+		for (var line of editor.getBuffer().lines) {
+			if (line.length) {
+			 	if (/(\bimport\b|^\s*\/\*|\bcomponent\b|\binterface\b)/.test(line)) {
+					editor.setGrammar(module.cfscriptGrammar);
+				} else {
+					editor.setGrammar(module.cfmlGrammar);
+				}
+				break;
+			}
+		}
+		editor._checking_is_cfscript=false;
+	}
+}
+
+
+
+function bindChangeChecker(editor) {
+	editor._changeChecker = editor.emitter.on("did-change", function() {
+		checkCfscriptEditorGrammar(editor);
+	});
+}

--- a/package.json
+++ b/package.json
@@ -4,33 +4,10 @@
   "version": "0.8.0",
   "private": false,
   "description": "CFML syntax highlighting for ColdFusion, Railo and Luccee Server.",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atuttle/atom-language-cfml"
-  },
+  "repository": "https://github.com/atuttle/atom-language-cfml",
   "license": "MIT",
   "engines": {
     "atom": "*"
   },
-  "dependencies": {},
-  "readme": "# CFML Grammar for Atom\n\nThis project is based on an auto-generated [conversion][1] of [the official CFML TextMate Bundle][2], and is under active development.\n\nPull requests welcome.\n\n[1]: http://atom.io/docs/latest/converting-a-text-mate-bundle\n[2]: https://github.com/textmate/coldfusion.tmbundle\n",
-  "readmeFilename": "README.md",
-  "bugs": {
-    "url": "https://github.com/atuttle/atom-language-cfml/issues"
-  },
-  "homepage": "https://github.com/atuttle/atom-language-cfml",
-  "_id": "language-cfml@0.8.0",
-  "_shasum": "1e0dcdfeb1bb9735913387e038d4209db19cb372",
-  "_resolved": "file:..\\d-11566-11728-xthztr\\package.tgz",
-  "_from": "..\\d-11566-11728-xthztr\\package.tgz",
-  "_atomModuleCache": {
-    "version": 1,
-    "dependencies": [],
-    "extensions": {
-      ".json": [
-        "package.json"
-      ]
-    },
-    "folders": []
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,36 @@
 {
   "name": "language-cfml",
+  "main":"./lib/languageCFML",
   "version": "0.8.0",
   "private": false,
   "description": "CFML syntax highlighting for ColdFusion, Railo and Luccee Server.",
-  "repository": "https://github.com/atuttle/atom-language-cfml",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/atuttle/atom-language-cfml"
+  },
   "license": "MIT",
   "engines": {
     "atom": "*"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "readme": "# CFML Grammar for Atom\n\nThis project is based on an auto-generated [conversion][1] of [the official CFML TextMate Bundle][2], and is under active development.\n\nPull requests welcome.\n\n[1]: http://atom.io/docs/latest/converting-a-text-mate-bundle\n[2]: https://github.com/textmate/coldfusion.tmbundle\n",
+  "readmeFilename": "README.md",
+  "bugs": {
+    "url": "https://github.com/atuttle/atom-language-cfml/issues"
+  },
+  "homepage": "https://github.com/atuttle/atom-language-cfml",
+  "_id": "language-cfml@0.8.0",
+  "_shasum": "1e0dcdfeb1bb9735913387e038d4209db19cb372",
+  "_resolved": "file:..\\d-11566-11728-xthztr\\package.tgz",
+  "_from": "..\\d-11566-11728-xthztr\\package.tgz",
+  "_atomModuleCache": {
+    "version": 1,
+    "dependencies": [],
+    "extensions": {
+      ".json": [
+        "package.json"
+      ]
+    },
+    "folders": []
+  }
 }


### PR DESCRIPTION
Restored the extra classes for cfscript grammar, and added an activation module that smart-switches the grammar based on the editor contents for .cfc files.