### PR TITLE
Fixed Issue #33 & Other updates.

### DIFF
--- a/grammars/cfml.cson
+++ b/grammars/cfml.cson
@@ -1,4 +1,4 @@
-'scopeName': 'text.cf.cfml'
+'scopeName': 'source.cfml'
 'name': 'cfml'
 'fileTypes': [
   'cfm'
@@ -82,7 +82,7 @@
         'name': 'source.cfscript.embedded'
         'patterns': [
           {
-            'include': 'text.cf.cfscript' # Defer to cfscript Grammar.
+            'include': 'source.cfscript' # Defer to cfscript Grammar.
           }
         ]
       }
@@ -183,7 +183,7 @@
   'embedded-code':
     'patterns': [
       {
-        'include': 'source.js' #until cfscript is better.
+        'include': 'source.cfscript' #until cfscript is better.
       }
     ]
 
@@ -256,26 +256,5 @@
       }
       {
         'include': '#embedded-cf'
-      }
-    ]
-  'script-component-path':
-    'patterns': [
-      {
-        'match': '(\\w+\\.)+'
-        'name': 'entity.name.package'
-      }
-    ]
-  'script-component-ctor':
-    'patterns': [
-      {
-        'match': '\\w+'
-        'name': 'entity.name.type.component.constructor'
-      }
-    ]
-  'script-component-name':
-    'patterns': [
-      {
-        'match': '\\w+'
-        'name': 'entity.name.type.component'
       }
     ]

--- a/grammars/cfscript.cson
+++ b/grammars/cfscript.cson
@@ -1,5 +1,5 @@
-'scopeName': 'text.cf.cfscript'
-'name': 'CFScript'
+'scopeName': 'source.cfscript'
+'name': 'cfscript'
 'fileTypes': [
   'cfm'
   'cfml'

--- a/grammars/html-cfml.cson
+++ b/grammars/html-cfml.cson
@@ -5,7 +5,6 @@
   'cfml'
   'cfc'
 ]
-
 'patterns': [
   # Start the CFML Grammar.
   {

--- a/lib/languageCFML.js
+++ b/lib/languageCFML.js
@@ -1,15 +1,24 @@
 module.exports = {
 	activate: function() {
-		module.cfmlGrammar = atom.grammars.grammarForScopeName("text.cf.cfml");
-		module.cfscriptGrammar = atom.grammars.grammarForScopeName("text.cf.cfscript");
-
+		//	Listen for the addition of the CMFL grammar.
+		atom.grammars.onDidAddGrammar(function (grammar) {
+			switch (grammar.scopeName){
+				case "source.cfml":
+					module.cfmlGrammar = grammar;
+					break;
+				case "source.cfscript":
+					module.cfscriptGrammar = grammar;
+					break;
+			}
+		});
+		//	Listen for opening new files.
 		atom.workspace.emitter.on("did-open", function(tab){
 			if (tab.item.getURI().endsWith("cfc")) {
 				bindChangeChecker(tab.item);
 				return checkCfscriptEditorGrammar(tab.item);
 			}
 		});
-
+		//	Add listners to all existing text editor instances.
 		for (var editor of atom.workspace.getTextEditors()) {
 			if (editor.getURI().endsWith("cfc")) {
 				bindChangeChecker(editor);
@@ -25,15 +34,17 @@ module.exports = {
 function checkCfscriptEditorGrammar(editor) {
 	if (!editor._checking_is_cfscript) {
 		editor._checking_is_cfscript=true;
-
-		for (var line of editor.getBuffer().lines) {
-			if (line.length) {
-			 	if (/(\bimport\b|^\s*\/\*|\bcomponent\b|\binterface\b)/.test(line)) {
-					editor.setGrammar(module.cfscriptGrammar);
-				} else {
-					editor.setGrammar(module.cfmlGrammar);
+		if (!!module.cfmlGrammar && !!module.cfscriptGrammar) {
+			//	Only run this is the grammars have been defined.
+			for (var line of editor.getBuffer().lines) {
+				if (line.length) {
+				 	if (/(\bimport\b|^\s*\/\*|^\s*\/\/|\bcomponent\b|\binterface\b)/.test(line)) {
+						editor.setGrammar(module.cfscriptGrammar);
+					} else {
+						editor.setGrammar(module.cfmlGrammar);
+					}
+					break;
 				}
-				break;
 			}
 		}
 		editor._checking_is_cfscript=false;


### PR DESCRIPTION
Renames files to remove brackets. Added single line comment to lib/languageCFML.js for cfscript identification. Changed root scopes to 'source.cfml' and 'source.cfscript' to be consistent with other programming languages in the atom grammar environments.

Fixed Issue #33 by using evented assignment of module grammars.