### PR TITLE
Changes cfscript line/block comments from /**/ to //

### DIFF
--- a/settings/language-cfml.cson
+++ b/settings/language-cfml.cson
@@ -2,3 +2,6 @@
   'editor':
     'commentStart': '<!--- '
     'commentEnd': ' --->'
+'.text.script.cfscript, .source.cfscript':
+  'editor':
+    'commentStart': '// '


### PR DESCRIPTION
This will change the comment style in cfscript from ```/**/``` to ```//```. Works on both a single line and block selection.