### PR TITLE
Fix for the cffunction name parameter

### DIFF
--- a/grammars/cfml.cson
+++ b/grammars/cfml.cson
@@ -182,15 +182,46 @@
     'patterns': [
       {
         'captures':
-          '0':
+          '1':
             'name': 'entity.other.attribute-name.cfml'
           '3':
-            'name': 'punctuation.definition.string.begin'
-          '4':
-            'name': 'entity.name.function.cfml'
-          '5':
-            'name': 'punctuation.definition.string.end'
-        'match': '\\b([nN][aA][mM][Ee])\\b\\s*(=)\\s*(["\'])([A-Za-z$_0-9]+)(["\'])'
+            'patterns': [
+                {
+                    'begin': '"'
+                    'beginCaptures':
+                      '0':
+                        'name': 'punctuation.definition.string.begin.cfml'
+                    'end': '"'
+                    'endCaptures':
+                      '0':
+                        'name': 'punctuation.definition.string.end.cfml'
+                    'name': 'string.quoted.double.cfml'
+                    'patterns': [
+                        {
+                            'match': '[^"]+'
+                            'name': 'entity.name.function.cfml'
+                        }
+                    ]
+                }
+                {
+                    'begin': '\''
+                    'beginCaptures':
+                      '0':
+                        'name': 'punctuation.definition.string.begin.cfml'
+                    'end': '\''
+                    'endCaptures':
+                      '0':
+                        'name': 'punctuation.definition.string.end.cfml'
+                    'name': 'string.quoted.single.cfml'
+                    'patterns': [
+                        {
+                            'match': '[^\']+'
+                            'name': 'entity.name.function.cfml'
+                        }
+                    ]
+                }
+            ]
+        'match': '\\b([nN][aA][mM][Ee])\\b\\s*(=)\\s*(["\'][A-Za-z$_0-9]+["\'])'
       }
       {
         'include': '#tag-stuff'

--- a/spec/cfml-spec.js
+++ b/spec/cfml-spec.js
@@ -98,6 +98,49 @@ describe('cfml grammar', function() {
             expect(tokens[2][2]).toEqual({ value: '>', scopes: ['source.cfml', 'meta.tag.any.cfml', 'punctuation.definition.tag.cfml'] });
         });
 
+        it('tokenizes simple cffunctions with single quotes correctly', function() {
+            var tokens = grammar.tokenizeLines([
+                '<cffunction access=\'public\' returntype=\'void\' name=\'init\'>',
+                '    <cfreturn />',
+                '</cffunction>'
+            ].join('\n'));
+
+            console.log(tokens[0]);
+
+            expect(tokens[0][0]).toEqual({ value: '<', scopes: ['source.cfml', 'meta.tag.other.cfml'] });
+            expect(tokens[0][1]).toEqual({ value: 'cffunction', scopes: ['source.cfml', 'meta.tag.other.cfml', 'entity.name.tag.other.cfml'] });
+            expect(tokens[0][2]).toEqual({ value: ' ', scopes: ['source.cfml', 'meta.tag.other.cfml'] });
+            expect(tokens[0][3]).toEqual({ value: 'access', scopes: ['source.cfml', 'meta.tag.other.cfml', 'entity.other.attribute-name.cfml'] });
+            expect(tokens[0][4]).toEqual({ value: '=', scopes: ['source.cfml', 'meta.tag.other.cfml'] });
+            expect(tokens[0][5]).toEqual({ value: '\'', scopes: ['source.cfml', 'meta.tag.other.cfml', 'string.quoted.single.cfml', 'punctuation.definition.string.begin.cfml'] });
+            expect(tokens[0][6]).toEqual({ value: 'public', scopes: ['source.cfml', 'meta.tag.other.cfml', 'string.quoted.single.cfml'] });
+            expect(tokens[0][7]).toEqual({ value: '\'', scopes: ['source.cfml', 'meta.tag.other.cfml', 'string.quoted.single.cfml', 'punctuation.definition.string.end.cfml'] });
+            expect(tokens[0][8]).toEqual({ value: ' ', scopes: ['source.cfml', 'meta.tag.other.cfml'] });
+            expect(tokens[0][9]).toEqual({ value: 'returntype', scopes: ['source.cfml', 'meta.tag.other.cfml', 'entity.other.attribute-name.cfml'] });
+            expect(tokens[0][10]).toEqual({ value: '=', scopes: ['source.cfml', 'meta.tag.other.cfml'] });
+            expect(tokens[0][11]).toEqual({ value: '\'', scopes: ['source.cfml', 'meta.tag.other.cfml', 'string.quoted.single.cfml', 'punctuation.definition.string.begin.cfml'] });
+            expect(tokens[0][12]).toEqual({ value: 'void', scopes: ['source.cfml', 'meta.tag.other.cfml', 'string.quoted.single.cfml'] });
+            expect(tokens[0][13]).toEqual({ value: '\'', scopes: ['source.cfml', 'meta.tag.other.cfml', 'string.quoted.single.cfml', 'punctuation.definition.string.end.cfml'] });
+            expect(tokens[0][14]).toEqual({ value: ' ', scopes: ['source.cfml', 'meta.tag.other.cfml'] });
+            // Shouldn't the equals (=) sign have the same behavior here as in the other attribtues, even if the name is classed differently?
+            expect(tokens[0][15]).toEqual({ value: 'name', scopes: ['source.cfml', 'meta.tag.other.cfml', 'entity.other.attribute-name.cfml'] });
+            expect(tokens[0][16]).toEqual({ value: '=', scopes: ['source.cfml', 'meta.tag.other.cfml'] });
+            expect(tokens[0][17]).toEqual({ value: '\'', scopes: ['source.cfml', 'meta.tag.other.cfml', 'string.quoted.single.cfml', 'punctuation.definition.string.begin.cfml'] });
+            expect(tokens[0][18]).toEqual({ value: 'init', scopes: ['source.cfml', 'meta.tag.other.cfml', 'string.quoted.single.cfml', 'entity.name.function.cfml'] });
+            expect(tokens[0][19]).toEqual({ value: '\'', scopes: ['source.cfml', 'meta.tag.other.cfml', 'string.quoted.single.cfml', 'punctuation.definition.string.end.cfml'] });
+            expect(tokens[0][20]).toEqual({ value: '>', scopes: ['source.cfml', 'meta.tag.other.cfml'] });
+
+            expect(tokens[1][0]).toEqual({ value: '    ', scopes: ['source.cfml'] });
+            expect(tokens[1][1]).toEqual({ value: '<', scopes: ['source.cfml', 'meta.tag.any.cfml', 'punctuation.definition.tag.cfml'] });
+            expect(tokens[1][2]).toEqual({ value: 'cfreturn', scopes: ['source.cfml', 'meta.tag.any.cfml', 'entity.name.tag.cfml'] });
+            expect(tokens[1][3]).toEqual({ value: ' ', scopes: ['source.cfml', 'meta.tag.any.cfml'] });
+            expect(tokens[1][4]).toEqual({ value: '/>', scopes: ['source.cfml', 'meta.tag.any.cfml', 'punctuation.definition.tag.cfml'] });
+
+            expect(tokens[2][0]).toEqual({ value: '</', scopes: ['source.cfml', 'meta.tag.any.cfml', 'punctuation.definition.tag.cfml'] });
+            expect(tokens[2][1]).toEqual({ value: 'cffunction', scopes: ['source.cfml', 'meta.tag.any.cfml', 'entity.name.tag.cfml'] });
+            expect(tokens[2][2]).toEqual({ value: '>', scopes: ['source.cfml', 'meta.tag.any.cfml', 'punctuation.definition.tag.cfml'] });
+        });
+
         it('tokenizes a complex cffunction block correctly', function() {
             var tokens = grammar.tokenizeLines([
                 '<cffunction access="public" returntype="void" name="init">',

--- a/spec/cfml-spec.js
+++ b/spec/cfml-spec.js
@@ -79,7 +79,6 @@ describe('cfml grammar', function() {
             expect(tokens[0][12]).toEqual({ value: 'void', scopes: ['source.cfml', 'meta.tag.other.cfml', 'string.quoted.double.cfml'] });
             expect(tokens[0][13]).toEqual({ value: '"', scopes: ['source.cfml', 'meta.tag.other.cfml', 'string.quoted.double.cfml', 'punctuation.definition.string.end.cfml'] });
             expect(tokens[0][14]).toEqual({ value: ' ', scopes: ['source.cfml', 'meta.tag.other.cfml'] });
-            // Shouldn't the equals (=) sign have the same behavior here as in the other attribtues, even if the name is classed differently?
             expect(tokens[0][15]).toEqual({ value: 'name', scopes: ['source.cfml', 'meta.tag.other.cfml', 'entity.other.attribute-name.cfml'] });
             expect(tokens[0][16]).toEqual({ value: '=', scopes: ['source.cfml', 'meta.tag.other.cfml'] });
             expect(tokens[0][17]).toEqual({ value: '"', scopes: ['source.cfml', 'meta.tag.other.cfml', 'string.quoted.double.cfml', 'punctuation.definition.string.begin.cfml'] });
@@ -122,7 +121,6 @@ describe('cfml grammar', function() {
             expect(tokens[0][12]).toEqual({ value: 'void', scopes: ['source.cfml', 'meta.tag.other.cfml', 'string.quoted.single.cfml'] });
             expect(tokens[0][13]).toEqual({ value: '\'', scopes: ['source.cfml', 'meta.tag.other.cfml', 'string.quoted.single.cfml', 'punctuation.definition.string.end.cfml'] });
             expect(tokens[0][14]).toEqual({ value: ' ', scopes: ['source.cfml', 'meta.tag.other.cfml'] });
-            // Shouldn't the equals (=) sign have the same behavior here as in the other attribtues, even if the name is classed differently?
             expect(tokens[0][15]).toEqual({ value: 'name', scopes: ['source.cfml', 'meta.tag.other.cfml', 'entity.other.attribute-name.cfml'] });
             expect(tokens[0][16]).toEqual({ value: '=', scopes: ['source.cfml', 'meta.tag.other.cfml'] });
             expect(tokens[0][17]).toEqual({ value: '\'', scopes: ['source.cfml', 'meta.tag.other.cfml', 'string.quoted.single.cfml', 'punctuation.definition.string.begin.cfml'] });

--- a/spec/cfscript-spec.js
+++ b/spec/cfscript-spec.js
@@ -1,4 +1,4 @@
-fdescribe('cfml grammar', function() {
+describe('cfml grammar', function() {
   var grammar;
 
   beforeEach(function() {


### PR DESCRIPTION
The `name` parameter of cffunction did not tokenize the same as other
parameters.  This pull request fixes that issue.