### PR TITLE
Add new `html-cfml-injection` grammar to fix highlighting within normal strings

### DIFF
--- a/grammars/html-cfml-injection.cson
+++ b/grammars/html-cfml-injection.cson
@@ -1,0 +1,13 @@
+'name': 'HTML (CFML)'
+'scopeName': 'text.html.cfml'
+'fileTypes': [
+  'cfm'
+  'cfml'
+  'cfc'
+]
+'injectionSelector': 'string.quoted.double.html, string.quoted.single.html'
+'patterns': [
+  {
+    'include': 'source.cfml'
+  }
+]

--- a/grammars/html-cfml-injection.cson
+++ b/grammars/html-cfml-injection.cson
@@ -5,7 +5,7 @@
   'cfml'
   'cfc'
 ]
-'injectionSelector': 'string.quoted.double.html, string.quoted.single.html'
+'injectionSelector': 'meta.tag.* -comment.line.cfml'
 'patterns': [
   {
     'include': 'source.cfml'

--- a/grammars/html-cfml.cson
+++ b/grammars/html-cfml.cson
@@ -1,10 +1,6 @@
 'scopeName': 'text.html.cfml'
 'name': 'HTML (CFML)'
-'fileTypes': [
-  'cfm'
-  'cfml'
-  'cfc'
-]
+
 'patterns': [
   # Start the CFML Grammar.
   {

--- a/spec/html-cfml-spec.js
+++ b/spec/html-cfml-spec.js
@@ -1,4 +1,4 @@
-fdescribe('html-cfml grammar', function() {
+describe('html-cfml grammar', function() {
     var grammar;
 
     beforeEach(function() {

--- a/spec/html-cfml-spec.js
+++ b/spec/html-cfml-spec.js
@@ -1,4 +1,4 @@
-describe('html-cfml grammar', function() {
+fdescribe('html-cfml grammar', function() {
     var grammar;
 
     beforeEach(function() {
@@ -104,6 +104,64 @@ describe('html-cfml grammar', function() {
             expect(tokens[6][0]).toEqual({ value: '</', scopes: ['text.html.cfml', 'meta.tag.any.cfml', 'punctuation.definition.tag.cfml'] });
             expect(tokens[6][1]).toEqual({ value: 'cfoutput', scopes: ['text.html.cfml', 'meta.tag.any.cfml', 'entity.name.tag.cfml'] });
             expect(tokens[6][2]).toEqual({ value: '>', scopes: ['text.html.cfml', 'meta.tag.any.cfml', 'punctuation.definition.tag.cfml'] });
+        });
+    });
+
+    describe('tokenizing cfcomments', function() {
+        it('should tokenize cfcomments correctly', function() {
+            var tokens = grammar.tokenizeLines('<!--- cfcomment goes here --->');
+
+            expect(tokens[0][0]).toEqual({ value: '<!---', scopes: ['text.html.cfml', 'comment.line.cfml'] });
+            expect(tokens[0][1]).toEqual({ value: ' cfcomment goes here ', scopes: ['text.html.cfml', 'comment.line.cfml'] });
+            expect(tokens[0][2]).toEqual({ value: '--->', scopes: ['text.html.cfml', 'comment.line.cfml'] });
+        });
+
+        it('should tokenize cfcomments embedded in html tags correctly', function() {
+            var tokens = grammar.tokenizeLines('<input type="text" name="credit_card_number" <!--- embedded cfcomment ---> />');
+
+            expect(tokens[0][0]).toEqual({ value: '<', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'punctuation.definition.tag.begin.html'] });
+            expect(tokens[0][1]).toEqual({ value: 'input', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'entity.name.tag.inline.any.html'] });
+            expect(tokens[0][2]).toEqual({ value: ' ', scopes: ['text.html.cfml', 'meta.tag.inline.any.html'] });
+            expect(tokens[0][3]).toEqual({ value: 'type', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'entity.other.attribute-name.html'] });
+            expect(tokens[0][4]).toEqual({ value: '=', scopes: ['text.html.cfml', 'meta.tag.inline.any.html'] });
+            expect(tokens[0][5]).toEqual({ value: '"', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'string.quoted.double.html', 'punctuation.definition.string.begin.html'] });
+            expect(tokens[0][6]).toEqual({ value: 'text', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'string.quoted.double.html'] });
+            expect(tokens[0][7]).toEqual({ value: '"', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'string.quoted.double.html', 'punctuation.definition.string.end.html'] });
+            expect(tokens[0][8]).toEqual({ value: ' ', scopes: ['text.html.cfml', 'meta.tag.inline.any.html'] });
+            expect(tokens[0][9]).toEqual({ value: 'name', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'entity.other.attribute-name.html'] });
+            expect(tokens[0][10]).toEqual({ value: '=', scopes: ['text.html.cfml', 'meta.tag.inline.any.html'] });
+            expect(tokens[0][11]).toEqual({ value: '"', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'string.quoted.double.html', 'punctuation.definition.string.begin.html'] });
+            expect(tokens[0][12]).toEqual({ value: 'credit_card_number', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'string.quoted.double.html'] });
+            expect(tokens[0][13]).toEqual({ value: '"', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'string.quoted.double.html', 'punctuation.definition.string.end.html'] });
+            expect(tokens[0][14]).toEqual({ value: ' ', scopes: ['text.html.cfml', 'meta.tag.inline.any.html'] });
+            expect(tokens[0][15]).toEqual({ value: '<!---', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'comment.line.cfml'] });
+            expect(tokens[0][16]).toEqual({ value: ' embedded cfcomment ', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'comment.line.cfml'] });
+            expect(tokens[0][17]).toEqual({ value: '--->', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'comment.line.cfml'] });
+            expect(tokens[0][18]).toEqual({ value: ' />', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'punctuation.definition.tag.end.html'] });
+        });
+
+        it('should not highlight hash signs in cfcomments', function() {
+            var tokens = grammar.tokenizeLines('<input type="text" name="credit_card_number" <!--- #rc.name# should not be tokenized ---> />');
+
+            expect(tokens[0][0]).toEqual({ value: '<', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'punctuation.definition.tag.begin.html'] });
+            expect(tokens[0][1]).toEqual({ value: 'input', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'entity.name.tag.inline.any.html'] });
+            expect(tokens[0][2]).toEqual({ value: ' ', scopes: ['text.html.cfml', 'meta.tag.inline.any.html'] });
+            expect(tokens[0][3]).toEqual({ value: 'type', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'entity.other.attribute-name.html'] });
+            expect(tokens[0][4]).toEqual({ value: '=', scopes: ['text.html.cfml', 'meta.tag.inline.any.html'] });
+            expect(tokens[0][5]).toEqual({ value: '"', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'string.quoted.double.html', 'punctuation.definition.string.begin.html'] });
+            expect(tokens[0][6]).toEqual({ value: 'text', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'string.quoted.double.html'] });
+            expect(tokens[0][7]).toEqual({ value: '"', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'string.quoted.double.html', 'punctuation.definition.string.end.html'] });
+            expect(tokens[0][8]).toEqual({ value: ' ', scopes: ['text.html.cfml', 'meta.tag.inline.any.html'] });
+            expect(tokens[0][9]).toEqual({ value: 'name', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'entity.other.attribute-name.html'] });
+            expect(tokens[0][10]).toEqual({ value: '=', scopes: ['text.html.cfml', 'meta.tag.inline.any.html'] });
+            expect(tokens[0][11]).toEqual({ value: '"', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'string.quoted.double.html', 'punctuation.definition.string.begin.html'] });
+            expect(tokens[0][12]).toEqual({ value: 'credit_card_number', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'string.quoted.double.html'] });
+            expect(tokens[0][13]).toEqual({ value: '"', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'string.quoted.double.html', 'punctuation.definition.string.end.html'] });
+            expect(tokens[0][14]).toEqual({ value: ' ', scopes: ['text.html.cfml', 'meta.tag.inline.any.html'] });
+            expect(tokens[0][15]).toEqual({ value: '<!---', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'comment.line.cfml'] });
+            expect(tokens[0][16]).toEqual({ value: ' #rc.name# should not be tokenized ', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'comment.line.cfml'] });
+            expect(tokens[0][17]).toEqual({ value: '--->', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'comment.line.cfml'] });
+            expect(tokens[0][18]).toEqual({ value: ' />', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'punctuation.definition.tag.end.html'] });
         });
     });
 

--- a/spec/html-cfml-spec.js
+++ b/spec/html-cfml-spec.js
@@ -201,10 +201,28 @@ fdescribe('html-cfml grammar', function() {
             expect(tokens[0][28]).toEqual({ value: 'cfoutput', scopes: ['text.html.cfml', 'meta.tag.any.cfml', 'entity.name.tag.cfml'] });
             expect(tokens[0][29]).toEqual({ value: '>', scopes: ['text.html.cfml', 'meta.tag.any.cfml', 'punctuation.definition.tag.cfml'] });
         });
+    });
 
-        it('should not tokenize embedded cf that is not surrounded by a <cfoutput> tag', function() {
-            // TODO
-        });
+    it('should not tokenize embedded cf that is not surrounded by a <cfoutput> tag', function() {
+        // TODO
+    });
+
+    it('should tokenize cfml in unquoted attributes', function() {
+        var tokens = grammar.tokenizeLines('<span class=#className#></span>');
+
+        expect(tokens[0][0]).toEqual({ value: '<', scopes: ['text.html.cfml', 'meta.tag.any.html', 'punctuation.definition.tag.html'] });
+        expect(tokens[0][1]).toEqual({ value: 'span', scopes: ['text.html.cfml', 'meta.tag.any.html', 'entity.name.tag.html'] });
+        expect(tokens[0][2]).toEqual({ value: ' ', scopes: ['text.html.cfml', 'meta.tag.any.html'] });
+        expect(tokens[0][3]).toEqual({ value: 'class', scopes: ['text.html.cfml', 'meta.tag.any.html', 'entity.other.attribute-name.html'] });
+        expect(tokens[0][4]).toEqual({ value: '=', scopes: ['text.html.cfml', 'meta.tag.any.html'] });
+        expect(tokens[0][5]).toEqual({ value: '#', scopes: ['text.html.cfml', 'meta.tag.any.html', 'string.unquoted.html', 'source.embedded.cf', 'source.embedded.punctuation.section'] });
+        expect(tokens[0][6]).toEqual({ value: 'className', scopes: ['text.html.cfml', 'meta.tag.any.html', 'string.unquoted.html', 'source.embedded.cf'] });
+        expect(tokens[0][7]).toEqual({ value: '#', scopes: ['text.html.cfml', 'meta.tag.any.html', 'string.unquoted.html', 'source.embedded.cf', 'source.embedded.punctuation.section'] });
+        expect(tokens[0][8]).toEqual({ value: '>', scopes: ['text.html.cfml', 'meta.tag.any.html', 'punctuation.definition.tag.html'] });
+        expect(tokens[0][9]).toEqual({ value: '</', scopes: ['text.html.cfml', 'meta.tag.any.html', 'punctuation.definition.tag.html'] });
+        expect(tokens[0][10]).toEqual({ value: 'span', scopes: ['text.html.cfml', 'meta.tag.any.html', 'entity.name.tag.html'] });
+        expect(tokens[0][11]).toEqual({ value: '>', scopes: ['text.html.cfml', 'meta.tag.any.html', 'punctuation.definition.tag.html'] });
+
     });
 
 });

--- a/spec/html-cfml-spec.js
+++ b/spec/html-cfml-spec.js
@@ -107,4 +107,46 @@ describe('html-cfml grammar', function() {
         });
     });
 
+    describe('tokenization in strings', function() {
+
+        it('should tokenize embedded cf in strings', function() {
+            var tokens = grammar.tokenizeLines('<cfoutput><a href="index.cfm?action=shopping.product-details.main&amp;details=#_.detail#">#variables.white_papers[_.detail][2]#</a></cfoutput>');
+
+            expect(tokens[0][0]).toEqual({ value: '<', scopes: ['text.html.cfml', 'meta.tag.any.cfml', 'punctuation.definition.tag.cfml'] });
+            expect(tokens[0][1]).toEqual({ value: 'cfoutput', scopes: ['text.html.cfml', 'meta.tag.any.cfml', 'entity.name.tag.cfml'] });
+            expect(tokens[0][2]).toEqual({ value: '>', scopes: ['text.html.cfml', 'meta.tag.any.cfml', 'punctuation.definition.tag.cfml'] });
+            expect(tokens[0][3]).toEqual({ value: '<', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'punctuation.definition.tag.begin.html'] });
+            expect(tokens[0][4]).toEqual({ value: 'a', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'entity.name.tag.inline.any.html'] });
+            expect(tokens[0][5]).toEqual({ value: ' ', scopes: ['text.html.cfml', 'meta.tag.inline.any.html'] });
+            expect(tokens[0][6]).toEqual({ value: 'href', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'entity.other.attribute-name.html'] });
+            expect(tokens[0][7]).toEqual({ value: '=', scopes: ['text.html.cfml', 'meta.tag.inline.any.html'] });
+            expect(tokens[0][8]).toEqual({ value: '"', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'string.quoted.double.html', 'punctuation.definition.string.begin.html'] });
+            expect(tokens[0][9]).toEqual({ value: 'index.cfm?action=shopping.product-details.main', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'string.quoted.double.html'] });
+            expect(tokens[0][10]).toEqual({ value: '&', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'string.quoted.double.html', 'constant.character.entity.html', 'punctuation.definition.entity.html'] });
+            expect(tokens[0][11]).toEqual({ value: 'amp', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'string.quoted.double.html', 'constant.character.entity.html'] });
+            expect(tokens[0][12]).toEqual({ value: ';', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'string.quoted.double.html', 'constant.character.entity.html', 'punctuation.definition.entity.html'] });
+            expect(tokens[0][13]).toEqual({ value: 'details=', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'string.quoted.double.html'] });
+            expect(tokens[0][14]).toEqual({ value: '#', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'string.quoted.double.html', 'source.embedded.cf', 'source.embedded.punctuation.section'] });
+            expect(tokens[0][15]).toEqual({ value: '_.detail', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'string.quoted.double.html', 'source.embedded.cf'] });
+            expect(tokens[0][16]).toEqual({ value: '#', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'string.quoted.double.html', 'source.embedded.cf', 'source.embedded.punctuation.section'] });
+            expect(tokens[0][17]).toEqual({ value: '"', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'string.quoted.double.html', 'punctuation.definition.string.end.html'] });
+            expect(tokens[0][18]).toEqual({ value: '>', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'punctuation.definition.tag.end.html'] });
+            expect(tokens[0][19]).toEqual({ value: '#', scopes: ['text.html.cfml', 'source.embedded.cf', 'source.embedded.punctuation.section'] });
+            expect(tokens[0][20]).toEqual({ value: 'variables', scopes: ['text.html.cfml', 'source.embedded.cf', 'entity.other.scope-name'] });
+            expect(tokens[0][21]).toEqual({ value: '.', scopes: ['text.html.cfml', 'source.embedded.cf'] });
+            expect(tokens[0][22]).toEqual({ value: 'white_papers[_.detail][2]', scopes: ['text.html.cfml', 'source.embedded.cf'] });
+            expect(tokens[0][23]).toEqual({ value: '#', scopes: ['text.html.cfml', 'source.embedded.cf', 'source.embedded.punctuation.section'] });
+            expect(tokens[0][24]).toEqual({ value: '</', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'punctuation.definition.tag.begin.html'] });
+            expect(tokens[0][25]).toEqual({ value: 'a', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'entity.name.tag.inline.any.html'] });
+            expect(tokens[0][26]).toEqual({ value: '>', scopes: ['text.html.cfml', 'meta.tag.inline.any.html', 'punctuation.definition.tag.end.html'] });
+            expect(tokens[0][27]).toEqual({ value: '</', scopes: ['text.html.cfml', 'meta.tag.any.cfml', 'punctuation.definition.tag.cfml'] });
+            expect(tokens[0][28]).toEqual({ value: 'cfoutput', scopes: ['text.html.cfml', 'meta.tag.any.cfml', 'entity.name.tag.cfml'] });
+            expect(tokens[0][29]).toEqual({ value: '>', scopes: ['text.html.cfml', 'meta.tag.any.cfml', 'punctuation.definition.tag.cfml'] });
+        });
+
+        it('should not tokenize embedded cf that is not surrounded by a <cfoutput> tag', function() {
+            // TODO
+        });
+    });
+
 });


### PR DESCRIPTION
I realize I could push this directly on to master, but I'd appreciate another set of eyes, at least.

This pull request introduces a new grammar `html-cfml-injection`.  This grammar injects itself in to html string, looks for hash signs (`#...#`), and tokenizes the contents between the hash signs as cfscript.

One thing it does not (yet) do is look and make sure the hash signs are inside a `<cfoutput>` tag pair first.

Tests are passing, but I'd love a beta round before pushing this out on everyone.

Fixes #53, potentially #45.