### PR TITLE
fix for #67 add support for custom tag highlighting

### DIFF
--- a/grammars/cfml.cson
+++ b/grammars/cfml.cson
@@ -528,7 +528,7 @@
       }
     ]
   'tag-start':
-    'begin': '(?i)(<)(cf[a-z]+)'
+    'begin': '(?i)(<)(cf_?[a-z]+)'
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.tag.begin.cfml'
@@ -548,7 +548,7 @@
     'patterns': [
       {
       'name': 'meta.tag.cfml'
-      'match': '((?:<(?=/[a-zA-Z0-9:-]+))?/)((?i:cf)[a-zA-Z0-9:-]+)?(>)'
+      'match': '((?:<(?=/[a-zA-Z0-9:-]+))?/)((?i:cf)_?[a-zA-Z0-9:-]+)?(>)'
       'captures':
         '1':
           'name': 'punctuation.definition.tag.begin.cfml'

--- a/spec/cfml-spec.js
+++ b/spec/cfml-spec.js
@@ -104,8 +104,6 @@ describe('cfml grammar', function() {
                 '</cffunction>'
             ].join('\n'));
 
-            console.log(tokens[0]);
-
             expect(tokens[0][0]).toEqual({ value: '<', scopes: ['source.cfml', 'meta.tag.cfml', 'punctuation.definition.tag.begin.cfml'] });
             expect(tokens[0][1]).toEqual({ value: 'cffunction', scopes: ['source.cfml', 'meta.tag.cfml', 'entity.name.tag.cfml'] });
             expect(tokens[0][2]).toEqual({ value: ' ', scopes: ['source.cfml', 'meta.tag.cfml'] });

--- a/spec/html-cfml-spec.js
+++ b/spec/html-cfml-spec.js
@@ -238,4 +238,17 @@ describe('html-cfml grammar', function() {
 
     });
 
+	it('should tokenize custom tags', function() {
+        var tokens = grammar.tokenizeLines('<cf_PageRow> </cf_PageRow>');
+
+        expect(tokens[0][0]).toEqual({ value: '<', scopes: ['text.html.cfml', 'meta.tag.cfml', 'punctuation.definition.tag.begin.cfml'] });
+        expect(tokens[0][1]).toEqual({ value: 'cf_PageRow', scopes: ['text.html.cfml', 'meta.tag.cfml', 'entity.name.tag.cfml'] });
+        expect(tokens[0][2]).toEqual({ value: '>', scopes: ['text.html.cfml', 'meta.tag.cfml', 'punctuation.definition.tag.end.cfml'] });
+        expect(tokens[0][3]).toEqual({ value: ' ', scopes: ['text.html.cfml'] });
+        expect(tokens[0][4]).toEqual({ value: '</', scopes: ['text.html.cfml', 'meta.tag.cfml', 'punctuation.definition.tag.begin.cfml'] });
+        expect(tokens[0][5]).toEqual({ value: 'cf_PageRow', scopes: ['text.html.cfml', 'meta.tag.cfml', 'entity.name.tag.cfml'] });
+        expect(tokens[0][6]).toEqual({ value: '>', scopes: ['text.html.cfml', 'meta.tag.cfml', 'punctuation.definition.tag.end.cfml'] });
+
+    });
+
 });


### PR DESCRIPTION
Add support for custom tag highlighting, add a custom tag test, remove stray console log. #67 
![customgrammer](https://cloud.githubusercontent.com/assets/4008169/16272144/a2a6c7e6-386a-11e6-967e-c66c22b86400.gif)
