### PR TITLE
prevent /> from matching tag-end. Fixes #88

### DIFF
--- a/grammars/cfml.cson
+++ b/grammars/cfml.cson
@@ -548,7 +548,7 @@
     'patterns': [
       {
       'name': 'meta.tag.cfml'
-      'match': '((?:<(?=/[a-zA-Z0-9:-]+))?/)((?i:cf)_?[a-zA-Z0-9:-]+)?(>)'
+      'match': '((?:<(?=/[a-zA-Z0-9:-]+))?/)((?i:cf)_?[a-zA-Z0-9:-]+)(>)'
       'captures':
         '1':
           'name': 'punctuation.definition.tag.begin.cfml'


### PR DESCRIPTION
Custom selfclosing tags now highlight correctly. Fixes #88 