### PR TITLE
Update tag regex to recognize numbers and underscores in custom tags

### DIFF
--- a/grammars/cfml.cson
+++ b/grammars/cfml.cson
@@ -528,7 +528,7 @@
       }
     ]
   'tag-start':
-    'begin': '(?i)(<)(cf_?[a-z]+)'
+    'begin': '(?i)(<)(cf_?[a-z_][a-z0-9_]*)'
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.tag.begin.cfml'
@@ -548,7 +548,7 @@
     'patterns': [
       {
       'name': 'meta.tag.cfml'
-      'match': '((?:<(?=/[a-zA-Z0-9:-]+))?/)((?i:cf)_?[a-zA-Z0-9:-]+)(>)'
+      'match': '((?:<(?=/[a-zA-Z0-9:-]+))?/)((?i:cf)_?[_a-zA-Z0-9:-]+)(>)'
       'captures':
         '1':
           'name': 'punctuation.definition.tag.begin.cfml'


### PR DESCRIPTION
Previously underscores and numbers caused custom tags not to render correctly.
As seen here:
![beforefix](https://cloud.githubusercontent.com/assets/4008169/19602908/06aff4d0-977d-11e6-9304-fd435ee5e8c2.gif)

This PR fixes the regex to where they render like such:
![afterfix](https://cloud.githubusercontent.com/assets/4008169/19602924/174a33a0-977d-11e6-8ea1-769a9a0103dc.gif)
