### PR TITLE
CFC Extends parameter.

### DIFF
--- a/grammars/cfscript.cson
+++ b/grammars/cfscript.cson
@@ -101,7 +101,7 @@
         'beginCaptures':
           '1':
             'name': 'storage.modifier.extends.cfml'
-        'end': '(["\'])([a-zA-Z0-9:.]+)(["\'])|([a-zA-Z0-9:.]+)'
+        'end': '(["\'])([_a-zA-Z0-9:.]+)(["\'])|([_a-zA-Z0-9:.]+)'
         'endCaptures':
           '1':
             'name': 'punctuation.definition.string.begin.cfml'


### PR DESCRIPTION
When extending a CFC, the file name of the file being extended should allow for the underscore ( _ ) character.