### PR TITLE
cfoutput shouldn't be injected in a comment block

### DIFF
--- a/grammars/html-cfml.cson
+++ b/grammars/html-cfml.cson
@@ -5,7 +5,7 @@
   'cfml'
 ]
 'injections':
-  'meta.scope.cfoutput.cfml, meta.scope.cfoutput.js.cfml':
+  '(meta.scope.cfoutput.cfml, meta.scope.cfoutput.js.cfml) - comment.block.cfml':
     'patterns': [
       {
         'include': 'source.cfml#hash-delimiters'


### PR DESCRIPTION
When inside a comment, # could still trigger tokenization while inside a cfoutput. This adds a check for commenting before tokenizing/injecting grammer.
Before:
![before](https://cloud.githubusercontent.com/assets/4008169/21153458/9310c7bc-c138-11e6-88ce-2e5e76498714.gif)
After:
![after](https://cloud.githubusercontent.com/assets/4008169/21153460/96d6ec8c-c138-11e6-9f39-e74f0c805f87.gif)
