### PR TITLE
Fixed checkCfscriptEditorGrammar function throwing symbol.iterator error

### DIFF
--- a/lib/languageCFML.js
+++ b/lib/languageCFML.js
@@ -19,7 +19,7 @@ module.exports = {
 					break;
 			}
 		});
-		
+
 		//	Observes all currently open editors, and editors opened in the future
 		module.editorObserver = atom.workspace.observeTextEditors(function(editor) {
 			// apparently sometimes the uri can be null
@@ -37,7 +37,7 @@ module.exports = {
 			}
 		});
 	}
-	
+
 	,deactivate: function() {
 		// dispose of attached events
 		module.grammarObserver.dispose();
@@ -48,7 +48,7 @@ module.exports = {
 				delete editor._cfcChangeChecker;
 			}
 		}
-		
+
 		delete module.grammarObserver;
 		delete module.editorObserver;
 		delete module.htmlCfmlGrammar;
@@ -67,7 +67,8 @@ function checkCfscriptEditorGrammar(editor) {
 	) {
 		editor._checking_is_cfscript=true;
 		//	Only run this is the grammars have been defined.
-		for (var line of editor.getBuffer().lines) {
+		
+		for (var line of editor.getBuffer().getLines()) {
 			if (line.length) {
 			 	if (/(\bimport\b|^\s*\/\*|^\s*\/\/|\bcomponent\b|\binterface\b)/.test(line)) {
 					editor.setGrammar(module.cfscriptGrammar);


### PR DESCRIPTION
Excuse my editors liberal stripping of white space, fixing the issue with Atom v 1.19 